### PR TITLE
Fix horizontal scroll on small viewports

### DIFF
--- a/src/views/Listing/listing.css
+++ b/src/views/Listing/listing.css
@@ -16,7 +16,7 @@
     height: 16rem;
     width: 100%;
     background: #f8faff;
-    transform: skewY(-6deg) scaleX(1.2);
+    transform: skewY(-6deg);
     box-shadow: 0 -16px 32px -12px rgba(62,57,107,0.33);
     @media (max-width: 480px) {
       position: absolute -50px 0 auto 0;


### PR DESCRIPTION
Fixes #1 

The `scaleX` on the `::before` pseudo-element, as far as I see, doesn't add any visual changes but adds an horizontal scroll to the body on small viewports, at least in Safari 11 on iPhone X and iPhone 6.

This could be fixed adding `overflow-x: hidden` to the `.listing` class, but it caused to hide the `::before` pseudo-element. Also it would have been possible to fix by adding `overflow-x: hidden` to another ancestor, but I think is more clear to remove the `scaleX`.